### PR TITLE
Update openapi swagger specs

### DIFF
--- a/packages/httpServer/dependencies/health/index.js
+++ b/packages/httpServer/dependencies/health/index.js
@@ -1,6 +1,7 @@
 export default ({
   dependencies: {
     routes,
+    joi,
     http: {
       status: {
         OK
@@ -19,20 +20,35 @@ export default ({
     ctx.status = OK
   }
 
-  const error = () => {
+  const errorHandler = () => {
     throw new Error('You get an error!')
   }
 
+  const health = joi.object().keys({
+    status: joi.string(),
+    healthy: joi.boolean()
+  });
+
+  const error = joi.object().keys({
+    message: joi.string()
+  });
+
   routes.push({
     method: GET,
-    name: 'Health Check',
+    name: 'health',
     path: '/health',
+    schema: {
+      responseBody: health
+    },
     handler
   })
   routes.push({
     method: GET,
-    name: 'Get Error',
+    name: 'error',
     path: '/error',
-    handler: error
+    schema: {
+      responseBody: error
+    },
+    handler: errorHandler
   })
 }

--- a/packages/httpServer/dependencies/health/index.js
+++ b/packages/httpServer/dependencies/health/index.js
@@ -27,11 +27,11 @@ export default ({
   const health = joi.object().keys({
     status: joi.string(),
     healthy: joi.boolean()
-  });
+  })
 
   const error = joi.object().keys({
     message: joi.string()
-  });
+  })
 
   routes.push({
     method: GET,

--- a/packages/httpServer/dependencies/swagger/createSwaggerDefinition/index.js
+++ b/packages/httpServer/dependencies/swagger/createSwaggerDefinition/index.js
@@ -78,7 +78,7 @@ const getQueryParams = route => {
   return params
 }
 
-const jsonSchema = (schema, description = "Okay") => ({
+const jsonSchema = (schema, description = 'Okay') => ({
   description,
   content: {
     'application/json': {
@@ -87,7 +87,7 @@ const jsonSchema = (schema, description = "Okay") => ({
       }
     }
   }
-});
+})
 
 const requestBody = schema => `${schema}-${REQUEST_BODY}`
 

--- a/packages/httpServer/dependencies/swagger/createSwaggerDefinition/index.js
+++ b/packages/httpServer/dependencies/swagger/createSwaggerDefinition/index.js
@@ -78,7 +78,7 @@ const getQueryParams = route => {
   return params
 }
 
-const jsonSchema = (schema, description) => ({
+const jsonSchema = (schema, description = "Okay") => ({
   description,
   content: {
     'application/json': {
@@ -87,16 +87,17 @@ const jsonSchema = (schema, description) => ({
       }
     }
   }
-})
-const DEFAULT_RESPONSES = {
-  [BAD_REQUEST]: {},
-  [UNAUTHORIZED]: {},
-  [INTERNAL_SERVER_ERROR]: {}
-}
+});
 
 const requestBody = schema => `${schema}-${REQUEST_BODY}`
 
 const responseBody = schema => `${schema}-${RESPONSE_BODY}`
+
+const DEFAULT_RESPONSES = {
+  [BAD_REQUEST]: jsonSchema(`${responseBody('error')}`, 'Bad Request'),
+  [UNAUTHORIZED]: jsonSchema(`${responseBody('error')}`, 'Unauthorized'),
+  [INTERNAL_SERVER_ERROR]: jsonSchema(`${responseBody('error')}`, 'Internal Server Error')
+}
 
 const formatters = {
   get: schema => ({

--- a/packages/httpServer/package.json
+++ b/packages/httpServer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@b-mo/http-server",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "",
   "main": "index.js",
   "author": "tsteele",


### PR DESCRIPTION
Include descriptions in response bodies.
Add expected response schema to error and health routes.